### PR TITLE
Correcty resey TB hit counter

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -35,7 +35,8 @@ ThreadPool Threads; // Global object
 Thread::Thread() {
 
   resetCalls = exit = false;
-  maxPly = callsCnt = tbHits = 0;
+  maxPly = callsCnt = 0;
+  tbHits = 0;
   history.clear();
   counterMoves.clear();
   idx = Threads.size(); // Start from 0
@@ -158,7 +159,7 @@ void ThreadPool::read_uci_options() {
 
 /// ThreadPool::nodes_searched() returns the number of nodes searched
 
-uint64_t ThreadPool::nodes_searched() {
+uint64_t ThreadPool::nodes_searched() const {
 
   uint64_t nodes = 0;
   for (Thread* th : *this)
@@ -169,7 +170,7 @@ uint64_t ThreadPool::nodes_searched() {
 
 /// ThreadPool::tb_hits() returns the number of TB hits
 
-uint64_t ThreadPool::tb_hits() {
+uint64_t ThreadPool::tb_hits() const {
 
   uint64_t hits = 0;
   for (Thread* th : *this)
@@ -210,6 +211,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
   for (Thread* th : Threads)
   {
       th->maxPly = 0;
+      th->tbHits = 0;
       th->rootDepth = DEPTH_ZERO;
       th->rootMoves = rootMoves;
       th->rootPos.set(pos.fen(), pos.is_chess960(), &setupStates->back(), th);

--- a/src/thread.h
+++ b/src/thread.h
@@ -99,8 +99,8 @@ struct ThreadPool : public std::vector<Thread*> {
   MainThread* main() { return static_cast<MainThread*>(at(0)); }
   void start_thinking(Position&, StateListPtr&, const Search::LimitsType&);
   void read_uci_options();
-  uint64_t nodes_searched();
-  uint64_t tb_hits();
+  uint64_t nodes_searched() const;
+  uint64_t tb_hits() const;
 
 private:
   StateListPtr setupStates;


### PR DESCRIPTION
Restore original behaviour to reset
the counter before a new move search.

Also fixed some warnings and added const
qualifier to a couple of functions, as
suggested by m_stembera.

Thanks to Werner Bergmans for reporting
the regression.

No functional change.
